### PR TITLE
Handle OutputDir missing

### DIFF
--- a/AssemblyPublicizer/PublicizeTask.cs
+++ b/AssemblyPublicizer/PublicizeTask.cs
@@ -50,7 +50,7 @@ namespace AssemblyPublicizer
 
             if (!Directory.Exists(OutputDir))
             {
-                Log.LogMessage($"OutputDir missing. Creating {OutputDir}.");
+                Log.LogWarning($"OutputDir missing. Creating {OutputDir}.");
                 Directory.CreateDirectory(OutputDir);
             }
             var outputPath = Path.Combine(OutputDir, $"{filename}{OutputSuffix}.dll");

--- a/AssemblyPublicizer/PublicizeTask.cs
+++ b/AssemblyPublicizer/PublicizeTask.cs
@@ -47,6 +47,12 @@ namespace AssemblyPublicizer
             
             var moduleDefinition = ModuleDefinition.FromFile(assemblyPath);
             moduleDefinition.Publicize(PublicizeExplicitImpls);
+
+            if (!Directory.Exists(OutputDir))
+            {
+                Log.LogMessage($"OutputDir missing. Creating {OutputDir}.");
+                Directory.CreateDirectory(OutputDir);
+            }
             var outputPath = Path.Combine(OutputDir, $"{filename}{OutputSuffix}.dll");
             moduleDefinition.Write(outputPath);
             return true;

--- a/AssemblyPublicizerTest/AssemblyPublicizerTest.csproj
+++ b/AssemblyPublicizerTest/AssemblyPublicizerTest.csproj
@@ -35,9 +35,11 @@
       <None Update="fixtures\AccessTest.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="fixtures\TestProjectMissingOutDir.csproj.xml">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
       <None Update="fixtures\TestProject.csproj.xml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </None>
     </ItemGroup>
-
 </Project>

--- a/AssemblyPublicizerTest/PatcherTest.cs
+++ b/AssemblyPublicizerTest/PatcherTest.cs
@@ -31,5 +31,19 @@ namespace AssemblyPublicizerTest
             projectCollection.UnregisterAllLoggers();
             Assert.True(ok);
         }
+
+        [Fact]
+        public void TestFullProjectBuild_MissingOutputDir()
+        {
+            List<ILogger> loggers = new() { _xunitLogger };
+            var projectCollection = new ProjectCollection();
+            projectCollection.RegisterLoggers(loggers);
+            string fixtureDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "fixtures");
+            string projPath = Path.Combine(fixtureDir, "TestProjectMissingOutDir.csproj.xml");
+            var project = projectCollection.LoadProject(projPath);
+            var ok = project.Build();
+            projectCollection.UnregisterAllLoggers();
+            Assert.True(ok);
+        }
     }
 }

--- a/AssemblyPublicizerTest/fixtures/TestProjectMissingOutDir.csproj.xml
+++ b/AssemblyPublicizerTest/fixtures/TestProjectMissingOutDir.csproj.xml
@@ -1,0 +1,14 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublicizeTaskAssembly>$(MSBuildThisFileDirectory)..\AssemblyPublicizer.dll</PublicizeTaskAssembly>
+  </PropertyGroup>
+  <UsingTask TaskName="AssemblyPublicizer.PublicizeTask" AssemblyFile="$(PublicizeTaskAssembly)" />
+  <ItemGroup>
+    <PublicizeInputAssemblies Include="AccessTest.dll"/>
+  </ItemGroup>
+  <UsingTask TaskName="RemoveDir" AssemblyFile="$(MSBuildToolsPath)/Microsoft.Build.Tasks.Core.dll" />
+  <Target Name="Publicize">
+    <RemoveDir Directories="$(MSBuildThisFileDirectory)/missing" />
+    <AssemblyPublicizer.PublicizeTask InputAssemblies="@(PublicizeInputAssemblies)" OutputDir="$(MSBuildThisFileDirectory)/missing"/>
+  </Target>
+</Project>


### PR DESCRIPTION
If the OutputDir does not exist the write command will fail. Now it creates the directory if OutputDir doesn't exist.