### PR TITLE
print new hash to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+.vs/

--- a/AssemblyPublicizer/AssemblyPublicizer.csproj
+++ b/AssemblyPublicizer/AssemblyPublicizer.csproj
@@ -16,6 +16,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Copyright>2021 Vikash Balasubramanian</Copyright>
         <RepositoryType>git</RepositoryType>
+        <AssemblyVersion>1.0.2</AssemblyVersion>
+        <FileVersion>1.0.2</FileVersion>
+        <Version>1.0.2</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/AssemblyPublicizer/PublicizeTask.cs
+++ b/AssemblyPublicizer/PublicizeTask.cs
@@ -17,14 +17,14 @@ namespace AssemblyPublicizer
         [Required] public virtual string OutputDir { get; set; } = Directory.GetCurrentDirectory();
 
         public virtual bool PublicizeExplicitImpls { get; set; } = false;
-        
+
         public override bool Execute()
         {
             Log.LogMessage($"Publicizing {InputAssemblies.Length} input assemblies provided");
             return InputAssemblies.Aggregate(true, (current, assembly) => current & PublicizeItem(assembly.ItemSpec));
         }
 
-        private bool PublicizeItem (string assemblyPath)
+        private bool PublicizeItem(string assemblyPath)
         {
             if (!File.Exists(assemblyPath))
             {
@@ -36,15 +36,15 @@ namespace AssemblyPublicizer
             var hashPath = Path.Combine(OutputDir, $"{filename}{OutputSuffix}.hash");
 
             var lastHash = File.Exists(hashPath) ? File.ReadAllText(hashPath) : null;
-            
-            
+
+
             if (curHash == lastHash)
             {
-                Log.LogMessage("Public assembly is up to date.");
+                Log.LogMessage(MessageImportance.High, $"Public assembly {filename} is up to date.");
                 return true;
             }
-            Log.LogMessage($"Generating publicized assembly from {assemblyPath}");
-            
+            Log.LogMessage(MessageImportance.High, $"Generating publicized assembly from {assemblyPath}");
+
             var moduleDefinition = ModuleDefinition.FromFile(assemblyPath);
             moduleDefinition.Publicize(PublicizeExplicitImpls);
 
@@ -55,6 +55,8 @@ namespace AssemblyPublicizer
             }
             var outputPath = Path.Combine(OutputDir, $"{filename}{OutputSuffix}.dll");
             moduleDefinition.Write(outputPath);
+
+            File.WriteAllText(hashPath, curHash);
             return true;
         }
 


### PR DESCRIPTION
Great idea to check the hash before publicizing the assembly. But the hash is never saved to disk, so it still runs every time. This fixes it.

I took the opportunity to increase the logging importance. Otherwise it won't print anything, if the settings are on default (low verbosity).